### PR TITLE
Use four clusters for ASCII mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Image BWG Clustering
 
 Utility script to cluster images into binary or trinary black/white/grey (BWG)
-representations. Images placed in the `input/` directory are clustered with
-either a pixel based renderer or a stylised circular representation and saved
-to the `output/` directory. By default, pixel mode exports 512×512 PNG files,
-while circle mode clusters on a 24×24 grid and renders crisp circular dots that
-are upscaled to 512×512 for easier viewing.
+representations, or into quad-tone ASCII art. Images placed in the `input/`
+directory are clustered with a pixel based renderer, a stylised circular
+representation, or exported as ASCII art and saved to the `output/` directory.
+By default, pixel mode exports 512×512 PNG files, circle mode clusters on a
+24×24 grid and renders crisp circular dots that are upscaled to 512×512, and
+ASCII mode produces a 64×64-character text file.
 
 ## Requirements
 
@@ -27,8 +28,9 @@ pip install pillow numpy
    python main.py --mode pixel --clusters 2
    ```
 
-3. Clustered PNG files are written to `output/` using the naming pattern
-   `<original-name>_<mode>_<clusters>.png`.
+3. Clustered outputs are written to `output/` using the naming pattern
+   `<original-name>_<mode>_<clusters>.<ext>`, where `.png` is used for the
+   raster modes and `.txt` for ASCII art.
 
 ## Command Line Options
 
@@ -36,9 +38,9 @@ pip install pillow numpy
 |-----------------|-----------------------------------------------------------------|---------|
 | `--input-dir`   | Directory containing images to process.                         | `input` |
 | `--output-dir`  | Destination directory for clustered PNG files.                  | `output`|
-| `--mode`        | Rendering style, either `pixel` or `circle`.                     | `pixel` |
-| `--clusters`    | Number of clusters (`2` for binary, `3` for trinary).            | `2`     |
-| `--size`        | Output size; images are resized to a square of this dimension.   | `512`   |
+| `--mode`        | Rendering style: `pixel`, `circle`, or `ascii`.                   | `pixel` |
+| `--clusters`    | Number of clusters for image outputs (`2` or `3`). ASCII mode always renders four tone levels. | `2`     |
+| `--size`        | Output size; 512 for images and 64 for ASCII art if unspecified. | –       |
 | `--max-iter`    | Maximum iterations used by the k-means clustering algorithm.     | `30`    |
 | `--tol`         | Early stopping tolerance for k-means centroid movement.          | `1e-4`  |
 | `--seed`        | Random seed for centroid initialisation.                         | `42`    |
@@ -53,3 +55,7 @@ pip install pillow numpy
   With three clusters, the mid-intensity group uses smaller black dots instead
   of grey ones. The clustering grid is fixed at 24×24, and the rendered dots are
   upscaled to a 512×512 output unless you override `--size`.
+- **ASCII mode**: converts each clustered pixel into characters (`@`, `#`, `:`,
+  or space) and writes the result as a plain text file using four tonal
+  clusters. The default output grid is 64×64 characters; specify `--size` to
+  change this resolution.


### PR DESCRIPTION
## Summary
- retain the ASCII art rendering workflow and expand it to always use four tonal clusters
- update the CLI help, runtime behaviour, and documentation to reflect the ASCII-specific cluster count and palette

## Testing
- python -m compileall main.py
- python main.py --mode ascii *(fails: missing numpy dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9edbc713083218ce11a80c3b6400f